### PR TITLE
RHF 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.5",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hook-form": "^7.60.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -4411,6 +4412,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.60.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
+      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.5"
+    "react-hook-form": "^7.60.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
-    "@eslint/eslintrc": "^3"
+    "typescript": "^5"
   }
 }

--- a/src/constants/step.tsx
+++ b/src/constants/step.tsx
@@ -27,15 +27,9 @@ export const step2: Step = {
       type: "text",
       required: true,
     },
-  ],
-};
-
-export const step3: Step = {
-  title: "마지막 스텝",
-  fieldList: [
     {
       name: "test3",
-      label: "다른 입력",
+      label: "마지막 입력",
       type: "text",
       required: true,
     },

--- a/src/constants/step.tsx
+++ b/src/constants/step.tsx
@@ -4,11 +4,13 @@ export const step1: Step = {
   title: "도서 정보",
   fieldList: [
     {
+      name: "bookTitle",
       label: "도서 제목",
       type: "text",
       required: true,
     },
     {
+      name: "test1",
       label: "이런 입력",
       type: "text",
       required: true,
@@ -20,6 +22,7 @@ export const step2: Step = {
   title: "다음 스텝",
   fieldList: [
     {
+      name: "test2",
       label: "저런 입력",
       type: "text",
       required: true,
@@ -31,6 +34,7 @@ export const step3: Step = {
   title: "마지막 스텝",
   fieldList: [
     {
+      name: "test3",
       label: "다른 입력",
       type: "text",
       required: true,

--- a/src/constants/step.tsx
+++ b/src/constants/step.tsx
@@ -1,0 +1,39 @@
+import { Step } from "@/types";
+
+export const step1: Step = {
+  title: "도서 정보",
+  fieldList: [
+    {
+      label: "도서 제목",
+      type: "text",
+      required: true,
+    },
+    {
+      label: "이런 입력",
+      type: "text",
+      required: true,
+    },
+  ],
+};
+
+export const step2: Step = {
+  title: "다음 스텝",
+  fieldList: [
+    {
+      label: "저런 입력",
+      type: "text",
+      required: true,
+    },
+  ],
+};
+
+export const step3: Step = {
+  title: "마지막 스텝",
+  fieldList: [
+    {
+      label: "다른 입력",
+      type: "text",
+      required: true,
+    },
+  ],
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,12 @@
 import type { AppProps } from "next/app";
+import { FormProvider, useForm } from "react-hook-form";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const methods = useForm();
+
+  return (
+    <FormProvider {...methods}>
+      <Component {...pageProps} />
+    </FormProvider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,12 @@
-import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 export default function Home() {
-  return (
-    <>
-      <Head>
-        <title>Create Next App</title>
-        <meta name="description" content="Multi Step Form" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+  const router = useRouter();
 
-      <div>
-        <main>main</main>
-      </div>
-    </>
-  );
+  useEffect(() => {
+    router.replace("/step1");
+  }, [router]);
+
+  return null;
 }

--- a/src/pages/step1/index.tsx
+++ b/src/pages/step1/index.tsx
@@ -1,9 +1,11 @@
 import { useFormContext } from "react-hook-form";
 import { useRouter } from "next/router";
+import { step1 } from "@/constants/step";
 
 export default function Step1Page() {
   const { register, handleSubmit } = useFormContext();
   const router = useRouter();
+  const { fieldList } = step1;
 
   const onNext = handleSubmit(() => {
     router.push("/step2");
@@ -12,7 +14,12 @@ export default function Step1Page() {
   return (
     <div>
       <form onSubmit={onNext}>
-        <input {...register("test")} placeholder="test" />
+        {fieldList.map((field) => (
+          <div key={field.name}>
+            <p>{field.label}</p>
+            <input {...register(field.name)} />
+          </div>
+        ))}
         <button type="submit">다음</button>
       </form>
     </div>

--- a/src/pages/step1/index.tsx
+++ b/src/pages/step1/index.tsx
@@ -1,0 +1,20 @@
+import { useFormContext } from "react-hook-form";
+import { useRouter } from "next/router";
+
+export default function Step1Page() {
+  const { register, handleSubmit } = useFormContext();
+  const router = useRouter();
+
+  const onNext = handleSubmit(() => {
+    router.push("/step2");
+  });
+
+  return (
+    <div>
+      <form onSubmit={onNext}>
+        <input {...register("test")} placeholder="test" />
+        <button type="submit">다음</button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/step1/index.tsx
+++ b/src/pages/step1/index.tsx
@@ -12,16 +12,14 @@ export default function Step1Page() {
   });
 
   return (
-    <div>
-      <form onSubmit={onNext}>
-        {fieldList.map((field) => (
-          <div key={field.name}>
-            <p>{field.label}</p>
-            <input {...register(field.name)} />
-          </div>
-        ))}
-        <button type="submit">다음</button>
-      </form>
-    </div>
+    <form onSubmit={onNext}>
+      {fieldList.map((field) => (
+        <div key={field.name}>
+          <p>{field.label}</p>
+          <input {...register(field.name)} />
+        </div>
+      ))}
+      <button type="submit">다음</button>
+    </form>
   );
 }

--- a/src/pages/step2/index.tsx
+++ b/src/pages/step2/index.tsx
@@ -1,0 +1,19 @@
+import { useFormContext } from "react-hook-form";
+
+export default function Step2Page() {
+  const { register, handleSubmit } = useFormContext();
+
+  const onSubmit = handleSubmit((data) => {
+    // some action
+    console.log("[submit]", data);
+  });
+
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        <input {...register("test2")} placeholder="test2" />
+        <button type="submit">다음</button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/step2/index.tsx
+++ b/src/pages/step2/index.tsx
@@ -11,16 +11,14 @@ export default function Step2Page() {
   });
 
   return (
-    <div>
-      <form onSubmit={onSubmit}>
-        {fieldList.map((field) => (
-          <div key={field.name}>
-            <p>{field.label}</p>
-            <input {...register(field.name)} />
-          </div>
-        ))}
-        <button type="submit">다음</button>
-      </form>
-    </div>
+    <form onSubmit={onSubmit}>
+      {fieldList.map((field) => (
+        <div key={field.name}>
+          <p>{field.label}</p>
+          <input {...register(field.name)} />
+        </div>
+      ))}
+      <button type="submit">제출</button>
+    </form>
   );
 }

--- a/src/pages/step2/index.tsx
+++ b/src/pages/step2/index.tsx
@@ -1,7 +1,9 @@
+import { step2 } from "@/constants/step";
 import { useFormContext } from "react-hook-form";
 
 export default function Step2Page() {
   const { register, handleSubmit } = useFormContext();
+  const { fieldList } = step2;
 
   const onSubmit = handleSubmit((data) => {
     // some action
@@ -11,7 +13,12 @@ export default function Step2Page() {
   return (
     <div>
       <form onSubmit={onSubmit}>
-        <input {...register("test2")} placeholder="test2" />
+        {fieldList.map((field) => (
+          <div key={field.name}>
+            <p>{field.label}</p>
+            <input {...register(field.name)} />
+          </div>
+        ))}
         <button type="submit">다음</button>
       </form>
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+export interface Field {
+  label: string;
+  type: "text";
+  required?: boolean;
+  hidden?: boolean;
+}
+
+export interface Step {
+  title: string;
+  fieldList: Field[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export interface Field {
+  name: string; // form 내에서 unique한 이름
   label: string;
   type: "text";
   required?: boolean;


### PR DESCRIPTION
## 배포 링크
https://form-template.multi-step-form-37c.pages.dev/

## 구현사항
- RHF 및 페이지 구조 세팅
  - 각 페이지의 입력값을 받아오기 위해 `FormProvider` 및 context 추가
  - 예시) 
    <img width="588" height="246" alt="image" src="https://github.com/user-attachments/assets/662d8d4e-bae7-426d-be1a-c22582de0cf3" />
    <img width="589" height="324" alt="image" src="https://github.com/user-attachments/assets/820eb27b-5f65-48ae-892f-8ee63641be80" />

- 대략적인 문항 데이터 구조 설계
  - `@/constants/step`에서 각 단계(`step`)와 문항(`field`)의 정보를 저장합니다.
  - `@/pages/step1`에서는 각 문항에 대한 정의 없이 렌더링만 이루어짐
  
